### PR TITLE
Add option to enable pretty URLS

### DIFF
--- a/.github/workflows/get-prettyurl-conf.yml
+++ b/.github/workflows/get-prettyurl-conf.yml
@@ -1,0 +1,34 @@
+name: get prettyurl conf
+
+on:
+  push:
+    branches:    
+    - '**'
+    - '!master'
+    - '![12][0-9]'
+    - '!develop'
+
+jobs:
+  get-prettyurl-conf:
+    name: Get Prettyurl conf
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Create local changes
+        run: |
+          chmod +x ./prettyurl.sh
+          bash -x ./prettyurl.sh
+      - name: Commit files
+        if: ${{ success() }}
+        continue-on-error: true
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Add prettyurl conf" -a
+      - name: Push changes
+        if: ${{ success() }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ If you want to disable the cronjob completely, run:
 
 To reenable it again simply set the `nextcloud.cron-interval` snap variable to a value that isn't `-1`
 
+#### Nextcloud Pretty URLs configuration
+
+If desired, the snap can remove the index.php part from the URL:
+
+    $ sudo snap set nextcloud nextcloud.prettyurls=true
+
+To disable it again just run:
+
+    $ sudo snap set nextcloud nextcloud.prettyurls=false
 
 #### Debug mode
 

--- a/prettyurl.sh
+++ b/prettyurl.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# For testing:
+# rm -rf nextcloud-snap
+# git clone --branch prettyurl https://github.com/nextcloud/nextcloud-snap.git
+# cd nextcloud-snap
+
+# Stop if something fails
+set -e
+
+# Get the correct tar file from the branch itself
+NC_DOMAIN="$(grep 'https://download.nextcloud.com/server' ./snap/snapcraft.yaml | grep -oP 'https://.*')"
+
+# Download the tar file
+curl -fL "$NC_DOMAIN" -o /tmp/ncpackage.tar.bz2
+
+# Extract the archive
+mkdir -p /tmp/nc
+tar -xjf /tmp/ncpackage.tar.bz2 -C /tmp/nc
+sudo chown -R www-data:www-data /tmp/nc
+sudo chmod -R 770 /tmp/nc
+
+# Set up PHP-FPM
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+    php-fpm \
+    php-intl \
+    php-ldap \
+    php-imap \
+    php-gd \
+    php-sqlite3 \
+    php-curl \
+    php-xml \
+    php-zip \
+    php-mbstring \
+    php-soap \
+    php-json \
+    php-gmp \
+    php-bz2 \
+    php-bcmath \
+    php-pear;
+
+# Install Nextcloud
+sudo -u www-data \
+    php -f /tmp/nc/nextcloud/occ \
+    maintenance:install \
+    --database=sqlite \
+    --admin-user=admin \
+    --admin-pass=password
+
+# Enable pretty URLS
+sudo -u www-data php -f /tmp/nc/nextcloud/occ config:system:set htaccess.RewriteBase --value="/"
+sudo -u www-data php -f /tmp/nc/nextcloud/occ maintenance:update:htaccess
+
+# Create file with final prettyurl config
+echo "# Retreived from $NC_DOMAIN" > /tmp/htaccess.conf
+
+# Get content of the changed htaccess file and write it to the new htaccess file
+sudo sed -e '1,/DO NOT CHANGE ANYTHING ABOVE THIS LINE/d' /tmp/nc/nextcloud/.htaccess >> /tmp/htaccess.conf
+
+# Overwrite changes
+cat /tmp/htaccess.conf > ./src/apache/conf/.htaccess

--- a/src/apache/bin/httpd-wrapper
+++ b/src/apache/bin/httpd-wrapper
@@ -8,6 +8,8 @@
 . "$SNAP/utilities/php-utilities"
 # shellcheck source=src/hooks/utilities/configuration-utilities
 . "$SNAP/utilities/configuration-utilities"
+# shellcheck source=src/nextcloud/utilities/nextcloud-utilities
+. "$SNAP/utilities/nextcloud-utilities"
 
 params=""
 if certificates_are_active; then
@@ -23,6 +25,13 @@ if certificates_are_active; then
 	fi
 else
 	echo "No certificates are active: using HTTP only"
+fi
+
+if should_enable_prettyurls; then
+	echo "Prettyurls is enabled"
+	params="$params -DEnablePrettyurls"
+else
+	echo "Prettyurls is disabled"
 fi
 
 if debug_mode_enabled; then

--- a/src/apache/conf/.htaccess
+++ b/src/apache/conf/.htaccess
@@ -1,0 +1,33 @@
+# Retreived from https://download.nextcloud.com/server/releases/nextcloud-21.0.3.tar.bz2
+
+ErrorDocument 403 /
+ErrorDocument 404 /
+<IfModule mod_rewrite.c>
+  Options -MultiViews
+  RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]
+  RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]
+  RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff2?|ico|jpg|jpeg|map|webm|mp4|mp3|ogg|wav)$
+  RewriteCond %{REQUEST_FILENAME} !core/img/favicon.ico$
+  RewriteCond %{REQUEST_FILENAME} !core/img/manifest.json$
+  RewriteCond %{REQUEST_FILENAME} !/remote.php
+  RewriteCond %{REQUEST_FILENAME} !/public.php
+  RewriteCond %{REQUEST_FILENAME} !/cron.php
+  RewriteCond %{REQUEST_FILENAME} !/core/ajax/update.php
+  RewriteCond %{REQUEST_FILENAME} !/status.php
+  RewriteCond %{REQUEST_FILENAME} !/ocs/v1.php
+  RewriteCond %{REQUEST_FILENAME} !/ocs/v2.php
+  RewriteCond %{REQUEST_FILENAME} !/robots.txt
+  RewriteCond %{REQUEST_FILENAME} !/updater/
+  RewriteCond %{REQUEST_FILENAME} !/ocs-provider/
+  RewriteCond %{REQUEST_FILENAME} !/ocm-provider/
+  RewriteCond %{REQUEST_URI} !^/\.well-known/(acme-challenge|pki-validation)/.*
+  RewriteCond %{REQUEST_FILENAME} !/richdocumentscode(_arm64)?/proxy.php$
+  RewriteRule . index.php [PT,E=PATH_INFO:$1]
+  RewriteBase /
+  <IfModule mod_env.c>
+    SetEnv front_controller_active true
+    <IfModule mod_dir.c>
+      DirectorySlash off
+    </IfModule>
+  </IfModule>
+</IfModule>

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -116,6 +116,11 @@ DocumentRoot "${SNAP}/htdocs"
     # on Snappy (since the .htaccess file is read-only) so we'll do it here so
     # as to avoid manually copying it in and needing to maintain it.
     Include ${SNAP}/htdocs/.htaccess
+
+    # Include a custom htaccess file for enabling Pretty URLs.
+    <IfDefine EnablePrettyurls>
+        Include ${SNAP}/conf/.htaccess
+    </IfDefine>
 </Directory>
 
 # Serve static assets for apps in a writable location.

--- a/src/hooks/bin/configure
+++ b/src/hooks/bin/configure
@@ -131,7 +131,29 @@ handle_mode()
 	snapctl restart nextcloud.php-fpm
 }
 
+handle_prettyurls_setting()
+{
+	prettyurls_status="$(snapctl get nextcloud.prettyurls)"
+	previous_prettyurls_status="$(nextcloud_previous_prettyurls_status)"
+
+	# Return if no new changes were requested
+	if [ "$prettyurls_status" = "$previous_prettyurls_status" ]; then
+		return 0;
+	fi
+
+	# Validate input
+	if [ "$prettyurls_status" = "true" ] || [ "$prettyurls_status" = "false" ] ; then
+		nextcloud_set_prettyurls_status "$prettyurls_status"
+		nextcloud_set_previous_prettyurls_status "$prettyurls_status"
+	fi
+
+	if ! restart_apache_if_running; then
+		return 1
+	fi
+}
+
 handle_apache_port_config && \
 handle_php_memory_limit && \
 handle_cronjob_interval && \
-handle_mode
+handle_mode && \
+handle_prettyurls_setting

--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -71,3 +71,40 @@ set_previous_cronjob_interval()
 {
 	snapctl set private.nextcloud.cron-interval="$1"
 }
+
+nextcloud_previous_prettyurls_status()
+{
+	snapctl get private.nextcloud.prettyurls
+}
+
+nextcloud_set_previous_prettyurls_status()
+{
+	snapctl set private.nextcloud.prettyurls="$1"
+}
+
+nextcloud_set_prettyurls_status()
+{
+	snapctl set nextcloud.prettyurls="$1"
+}
+
+nextcloud_prettyurls()
+{
+	prettyurls="$(snapctl get nextcloud.prettyurls)"
+
+	if [ -z "$prettyurls" ]; then
+		prettyurls="false"
+		nextcloud_set_prettyurls_status "false"
+		nextcloud_set_previous_prettyurls_status "false"
+	fi
+
+  echo "$prettyurls"
+}
+
+should_enable_prettyurls()
+{
+	if [ "$(nextcloud_prettyurls)" = "true" ]; then
+		return 0
+	else
+		return 1
+	fi
+}


### PR DESCRIPTION
Fix https://github.com/nextcloud/nextcloud-snap/issues/412

---

It works this way: every push that is pushed to any branch that is not called master, develop or '[12][0-9]' (this regex covers 10-29) will trigger the new workflow that downloads the current branch, runs the script that I wrote (My script basically sets up a temporary Nextcloud instance, enables pretty urls on it and writes all needed changes from there into a new .htaccess file.), changes the new .htaccess file to be based on the in the branch used nextcloud archive, commits the changes (if any) and pushes them to the same branch. This way you will be able to track any possible changes in the htaccess file in new Nextcloud versions in the future before merging into any of the mentioned branches.

If the feature gets enabled by the user it just includes my new .htaccess file in the apache conf which will automatically enable pretty urls for the users Nexcloud instance.

Signed-off-by: szaimen <szaimen@e.mail.de>