### PR TITLE
mysql: disable performance_schema

### DIFF
--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -6,3 +6,4 @@ skip-networking
 skip-log-bin
 transaction_isolation=READ-COMMITTED
 log_error=../logs/mysql_errors.log
+performance_schema=OFF


### PR DESCRIPTION
This was not enabled by default in mysql 5.7.x but it is on version 8.0.x:
https://dev.mysql.com/doc/refman/8.0/en/performance-schema-quick-start.html

This impacts low memory devices, so it should be disabled by default.