### PR TITLE
Update Nextcloud to 23.0.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-22.2.3.tar.bz2
-    source-checksum: sha256/66a29a6a490738c0abedb677cb68c7c91fabab3e6419a3c99d8b406899eb942a
+    source: https://download.nextcloud.com/server/releases/nextcloud-23.0.0.tar.bz2
+    source-checksum: sha256/c37592abc3b65c8fd28459281a24f414b87af52fc8c2ea979be3f9be75d01a2c
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
See https://github.com/nextcloud-snap/nextcloud-snap/issues/1958

Probably that's not the right way how-to but a first try. Don't know how to realize that it stays on edge or beta channel e.g.
Any suggestions are welcome 😅