### PR TITLE
Enable Movie files thumbnails creation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -281,9 +281,17 @@ parts:
       - libzip4
       - libargon2-0
       - libonig4
+      # For video thumbnails
+      - ffmpeg
+      - libslang2
     prime:
      - -sbin/
      - -etc/
+     # ffmpeg related
+     - -usr/share/man/
+     - -usr/lib/x86_64-linux-gnu/dri/
+     - -usr/share/alsa/
+     - -usr/share/doc/
     organize:
       # Put php-fpm in bin with everything else, not sbin.
       sbin/php-fpm: bin/php-fpm


### PR DESCRIPTION
Adding `ffmpeg` and `libslang2` to `php` `stage-packages` seems to do the trick, at least on my limited testing.

With this, you only need to add something of the like to the `config.php`:
```
'enabledPreviewProviders' => [
    'OC\Preview\Movie',
],
```

[Because `Movie` is not in the default enabled list](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#previews):
> due to performance or privacy concerns

And video files thumbnails will be created on demand when using Files to access folders that contain them.

I've also trimmed some unnecessary, I think, folders from the installed packages. Maybe some other files can also be deleted.
The biggest file is `usr/lib/x86_64-linux-gnu/libLLVM-10.so.1` weighting 71M on `amd64`.

The size of the snap goes from 239M to 277M (almost a 16% increment) in that same arch.

Regarding the security record of ffmpeg: [is not ideal](https://ffmpeg.org/security.html) but I would say that it's better than ImageMagick's one, [at least regarding impact of vulnerabilities](https://www.cvedetails.com/vulnerability-list/vendor_id-3611/Ffmpeg.html). [Their attitude regards security vulnerabilities being disclosed also seems much better](https://security.googleblog.com/2014/01/ffmpeg-and-thousand-fixes.html).

Another thing far from ideal is that the packet [is not in `main`, but `universe`](https://packages.ubuntu.com/bionic-updates/ffmpeg).

But the main bright point for me is that this optional and only called if the admin enables the preview provider.

If accepted, this would fix #1327

Any input is very welcome! Thanks!