### PR TITLE
ci: use snapcraft build container instead of destructive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: sudo apt-get update -qq && sudo snap install --classic snapcraft
+        run: sudo apt-get update -qq && sudo apt-get remove -qq lxd lxd-client && sudo snap install lxd && sudo lxd init --auto && sudo snap install --classic snapcraft
 
+      # Using sudo here because our CI user isn't a member of the lxd group
       - name: Build snap
-        run: snapcraft --destructive-mode
+        run: sudo snapcraft --provider lxd
 
       - name: Review snap
         run: sudo snap install review-tools && /snap/bin/review-tools.snap-review *.snap

--- a/tests/integration/spec_helper.rb
+++ b/tests/integration/spec_helper.rb
@@ -162,11 +162,10 @@ RSpec.configure do |config|
 		Capybara.current_session.driver.quit
 
 		# After each test, make sure maintenance mode is reset
-		`sudo nextcloud.occ -n maintenance:mode --off 2>&1`
-		expect($?.to_i).to eq 0
+		run 'sudo nextcloud.occ -n maintenance:mode --off 2>&1'
 
-		# Maintenance mode takes a second to apply (opcache)
-		sleep 2
+		# Maintenance mode takes two seconds to apply (opcache)
+		sleep 3
 
 		# Make sure any and all backups are removed
 		`sudo rm -rf /var/snap/nextcloud/common/backups`
@@ -176,8 +175,7 @@ RSpec.configure do |config|
 	end
 
 	def enable_https(port: nil)
-		`sudo nextcloud.enable-https self-signed`
-		expect($?.to_i).to eq 0
+		run 'sudo nextcloud.enable-https self-signed'
 		wait_for_nextcloud(https: true, port: port)
 	end
 
@@ -229,10 +227,8 @@ RSpec.configure do |config|
 			options_string += "#{key}=#{value} "
 		end
 
-		`sudo snap set nextcloud #{options_string}`
-		expect($?.to_i).to eq 0
-		`snap watch --last=configure-snap`
-		expect($?.to_i).to eq 0
+		run "sudo snap set nextcloud #{options_string}"
+		run 'snap watch --last=configure-snap'
 	end
 
 	def nextcloud_is_installed
@@ -242,8 +238,16 @@ RSpec.configure do |config|
 
 	def install_nextcloud
 		unless nextcloud_is_installed
-			`sudo nextcloud.manual-install admin admin`
+			run 'sudo nextcloud.manual-install admin admin'
+		end
+	end
+
+	def run(command, expect_success: true)
+		system(command)
+		if expect_success
 			expect($?.to_i).to eq 0
+		else
+			expect($?.to_i).not_to eq 0
 		end
 	end
 end


### PR DESCRIPTION
There are some dependencies leaking into the snap from the build host. Use LXD and build containers to isolate the snap from that type of thing.