### PR TITLE
snapcraft: move apache build/stage packages into plugin

### DIFF
--- a/snap/plugins/apache.py
+++ b/snap/plugins/apache.py
@@ -36,10 +36,9 @@ class ApachePlugin(snapcraft.plugins.v1.PluginV1):
         super().__init__(name, options, project)
 
         self.build_packages.extend(
-            ['pkg-config', 'libapr1-dev', 'libaprutil1-dev', 'libpcre3-dev',
+            ['pkg-config', 'libapr1-dev', 'libaprutil1-dev', 'libpcre2-dev',
              'libssl-dev'])
-        self.stage_packages.extend(['libapr1', 'libaprutil1'])
-
+        self.stage_packages.extend(['libapr1', 'libaprutil1', 'libpcre2-8-0'])
 
     def build(self):
         super().build()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -139,11 +139,9 @@ parts:
 
     build-packages:
       - libbrotli-dev
-      - libpcre2-dev
 
     stage-packages:
       - libbrotli1
-      - libpcre2-8-0
 
       # The built-in Apache modules to enable
     modules:


### PR DESCRIPTION
This was a mistake introduced in ff1d2a62736136b06ae46da732c8d0a08c88d877. Fix it.