### PR TITLE
ci: pin snapcraft to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get remove -qq lxd lxd-client && sudo snap install lxd && sudo lxd init --auto && sudo snap install --classic snapcraft
+        run: sudo apt-get update -qq && sudo apt-get remove -qq lxd lxd-client && sudo snap install lxd && sudo lxd init --auto && sudo snap install --classic --channel=6.x/stable snapcraft
 
       # Using sudo here because our CI user isn't a member of the lxd group
       - name: Build snap


### PR DESCRIPTION
Snapcraft v7 removed APIs used in our plugins without deprecating them. We need to rewrite our plugins to use new APIs (see #2122), but that will take time. Until then, pin our snapcraft use to v6.