### PR TITLE
Update opcache.interned_strings_buffer

### DIFF
--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -1773,7 +1773,7 @@ opcache.enable=1
 ;opcache.memory_consumption=128
 
 ; The amount of memory for interned strings in Mbytes.
-;opcache.interned_strings_buffer=8
+opcache.interned_strings_buffer=10
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; Only numbers between 200 and 1000000 are allowed.


### PR DESCRIPTION
The security and setup warnings page in the current version throws a warning about opcache configuration and recommends that opcache.interned_strings_buffer be defined with a value higher then 8 to assure that repeating strings can be effectively cached.