### PR TITLE
added support for export-directory for nextcloud.export

### DIFF
--- a/src/import-export/bin/export-data
+++ b/src/import-export/bin/export-data
@@ -22,7 +22,7 @@ FORMAT="1"
 print_usage()
 {
 	echo "Usage:"
-	echo "    $COMMAND [OPTIONS]"
+	echo "    $COMMAND [OPTIONS] [backup dir]"
 	echo "    Export data suitable for migrating servers. By default this"
 	echo "    includes the Nextcloud database, configuration, and data"
 	echo "    (equivalent to running $COMMAND -abcd)."
@@ -37,9 +37,9 @@ print_usage()
 
 export_apps()
 {
-	backup="$1"
+	backup_dir="$1"
 	echo "Exporting apps..."
-	if ! rsync -ah --info=progress2 "$SNAP_DATA/nextcloud/extra-apps/" "${backup}/apps"; then
+	if ! rsync -ah --info=progress2 "$SNAP_DATA/nextcloud/extra-apps/" "${backup_dir}/apps"; then
 		echo "Unable to export apps"
 		exit 1
 	fi
@@ -47,10 +47,10 @@ export_apps()
 
 export_database()
 {
-	backup="$1"
+	backup_dir="$1"
 	echo "Exporting database..."
 	if ! mysqldump --defaults-file="$MYSQL_ROOT_OPTION_FILE" \
-	             --lock-tables nextcloud > "${backup}/database.sql"; then
+	             --lock-tables nextcloud > "${backup_dir}/database.sql"; then
 		echo "Unable to export database"
 		exit 1
 	fi
@@ -58,8 +58,8 @@ export_database()
 
 export_config()
 {
-	backup="$1"
-	config_backup="${backup}/config.php"
+	backup_dir="$1"
+	config_backup="${backup_dir}/config.php"
 
 	# Mask out the config password. We don't need it when restoring.
 	echo "Exporting config..."
@@ -72,9 +72,9 @@ export_config()
 
 export_data()
 {
-	backup="$1"
+	backup_dir="$1"
 	echo "Exporting data..."
-	if ! rsync -ah --info=progress2 "${NEXTCLOUD_DATA_DIR%/}/" "${backup}/data"; then
+	if ! rsync -ah --info=progress2 "${NEXTCLOUD_DATA_DIR%/}/" "${backup_dir}/data"; then
 		echo "Unable to export data"
 		exit 1
 	fi
@@ -126,12 +126,15 @@ echo "development, use at your own risk. Note that the CLI interface is" >&2
 echo "unstable, so beware if using from within scripts." >&2
 echo "" >&2
 
-backup="${BACKUP_DIRECTORY}/$(date +%Y%m%d-%H%M%S)"
+backup_dir="$1"
+if [ -z "$backup_dir" ]; then
+  backup_dir="${BACKUP_DIRECTORY}/$(date +%Y%m%d-%H%M%S)"
+fi
 
-mkdir -p "$backup"
-chmod 750 "$backup"
+mkdir -p "$backup_dir"
+chmod 750 "$backup_dir"
 
-echo "$FORMAT" > "${backup}/format"
+echo "$FORMAT" > "${backup_dir}/format"
 
 # Enable maintenance mode so data can't change out from under us
 if ! enable_maintenance_mode; then
@@ -141,20 +144,20 @@ fi
 trap 'disable_maintenance_mode' EXIT
 
 if [ "$do_export_apps" = true ]; then
-	export_apps "$backup"
+	export_apps "$backup_dir"
 fi
 
 if [ "$do_export_database" = true ]; then
-	export_database "$backup"
+	export_database "$backup_dir"
 fi
 
 if [ "$do_export_config" = true ]; then
-	export_config "$backup"
+	export_config "$backup_dir"
 fi
 
 if [ "$do_export_data" = true ]; then
-	export_data "$backup"
+	export_data "$backup_dir"
 fi
 
 echo ""
-echo "Successfully exported $backup"
+echo "Successfully exported $backup_dir"


### PR DESCRIPTION
Hallo,

I'm currently moving my nextcloud instance to a new server. I noticed it is currently not possible to export the export-data to a custom folder. 

I wrote this pull request in the meantime while waiting for the copy of my data to an drive. So I can carry it to the new Server. I think this Option will have a lot of usage and timesaving for the users. In case of moving the data to another server you always need to copy the data.

I'm relatively new to shell-script so I hope my modifications to the export-script satisfy your standards.