### PR TITLE
integration tests: use input ID instead of label

### DIFF
--- a/src/nextcloud/utilities/nextcloud-utilities
+++ b/src/nextcloud/utilities/nextcloud-utilities
@@ -30,6 +30,13 @@ wait_for_nextcloud_to_be_installed()
 	wait_for_command "Waiting for Nextcloud to be installed" nextcloud_is_installed
 }
 
+nextcloud_is_in_maintenance_mode()
+{
+	# Urgh, occ still prints text warnings even with JSON output. Thus fromjson?.
+	maintenance="$(occ -n status --output=json | jq -R 'fromjson? | .maintenance')"
+	[ "$maintenance" = "true" ]
+}
+
 # nextcloud_notify_admins <short message> <long message>
 nextcloud_notify_admins()
 {

--- a/tests/integration/change_php_memory_limit_spec.rb
+++ b/tests/integration/change_php_memory_limit_spec.rb
@@ -43,8 +43,8 @@ feature "Change PHP memory limit" do
 
 	def assert_login
 		visit "/"
-		fill_in "User", with: "admin"
-		fill_in "Password", with: "admin"
+		fill_in "user", with: "admin"
+		fill_in "password", with: "admin"
 		click_button "Log in"
 		expect(page).to have_content /(Recommended|All) files/
 	end

--- a/tests/integration/enable_https_spec.rb
+++ b/tests/integration/enable_https_spec.rb
@@ -7,8 +7,8 @@ feature "Enabling HTTPS" do
 		enable_https
 
 		visit "/"
-		fill_in "User", with: "admin"
-		fill_in "Password", with: "admin"
+		fill_in "user", with: "admin"
+		fill_in "password", with: "admin"
 		click_button "Log in"
 		expect(page).to have_content /(Recommended|All) files/
 	end

--- a/tests/integration/import_export_spec.rb
+++ b/tests/integration/import_export_spec.rb
@@ -28,6 +28,7 @@ feature "Import and export data" do
 		`sudo mv "#{moved_backup}" "#{backup}"`
 		`sudo nextcloud.import "#{backup}"`
 		wait_for_nextcloud
+		wait_for_maintenance_mode_to_be_off
 		assert_loginable
 	end
 
@@ -35,8 +36,8 @@ feature "Import and export data" do
 
 	def assert_loginable
 		visit "/"
-		fill_in "User", with: "admin"
-		fill_in "Password", with: "admin"
+		fill_in "user", with: "admin"
+		fill_in "password", with: "admin"
 		click_button "Log in"
 		expect(page).to have_content /(Recommended|All) files/
 	end

--- a/tests/integration/login_spec.rb
+++ b/tests/integration/login_spec.rb
@@ -1,16 +1,16 @@
 feature "Logging in" do
 	scenario "Logging in with correct credentials" do
 		visit "/"
-		fill_in "User", with: "admin"
-		fill_in "Password", with: "admin"
+		fill_in "user", with: "admin"
+		fill_in "password", with: "admin"
 		click_button "Log in"
 		expect(page).to have_content /(Recommended|All) files/
 	end
 
 	scenario "Logging in with incorrect credentials" do
 		visit "/"
-		fill_in "User", with: "wronguser"
-		fill_in "Password", with: "wrongpassword"
+		fill_in "user", with: "wronguser"
+		fill_in "password", with: "wrongpassword"
 		click_button "Log in"
 		expect(page).to have_content /Wrong.*password/
 	end

--- a/tests/integration/spec_helper.rb
+++ b/tests/integration/spec_helper.rb
@@ -221,6 +221,20 @@ RSpec.configure do |config|
 		end
 	end
 
+	def wait_for_maintenance_mode_to_be_off
+		begin
+			Timeout.timeout(30) do
+				success = false
+				while not success
+					success = !nextcloud_is_in_maintenance_mode
+					sleep 1
+				end
+			end
+		rescue Timeout::Error
+				fail "Timed out waiting for maintenance mode to be off"
+		end
+	end
+
 	def set_config(options)
 		options_string = ""
 		options.each do |key, value|
@@ -233,6 +247,11 @@ RSpec.configure do |config|
 
 	def nextcloud_is_installed
 		`sudo snap run --shell nextcloud.occ -c '. "$SNAP/utilities/nextcloud-utilities" && nextcloud_is_installed'`
+		$?.to_i == 0
+	end
+
+	def nextcloud_is_in_maintenance_mode
+		`sudo snap run --shell nextcloud.occ -c '. "$SNAP/utilities/nextcloud-utilities" && nextcloud_is_in_maintenance_mode'`
 		$?.to_i == 0
 	end
 


### PR DESCRIPTION
The login labels changed in Nextcloud v25 such that these tests no longer pass. Start using the IDs instead, which remain consistent through at least the last few releases.