### PR TITLE
integration tests: wait for nextcloud fixer to finish

### DIFF
--- a/tests/integration/import_export_spec.rb
+++ b/tests/integration/import_export_spec.rb
@@ -28,6 +28,7 @@ feature "Import and export data" do
 		`sudo mv "#{moved_backup}" "#{backup}"`
 		`sudo nextcloud.import "#{backup}"`
 		wait_for_nextcloud
+		wait_for_nextcloud_fixer
 		wait_for_maintenance_mode_to_be_off
 		assert_loginable
 	end

--- a/tests/integration/spec_helper.rb
+++ b/tests/integration/spec_helper.rb
@@ -197,41 +197,43 @@ RSpec.configure do |config|
 			uri.port = port
 		end
 
-		success = false
-
-		begin
-			Timeout.timeout(30) do
-				while not success
-					begin
-						output = open(uri, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE})
-						success = output.readlines.join('').include? 'Nextcloud'
-					rescue Errno::ECONNREFUSED
-						# Do nothing: try again
-					rescue OpenURI::HTTPError => error
-						# Ignore 503s, wait for PHP to come up and try again
-						if error.io.status[0] != '503'
-							raise
-						end
-					end
-					sleep 1
+		wait_for("Timed out trying to access Nextcloud: #{uri.to_s}") do
+			begin
+				output = open(uri, {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE}).readlines.join('')
+				next output.include? 'Nextcloud'
+			rescue Errno::ECONNREFUSED
+				# Do nothing: try again
+			rescue OpenURI::HTTPError => error
+				# Ignore 503s, wait for PHP to come up and try again
+				if error.io.status[0] != '503'
+					raise
 				end
 			end
-		rescue Timeout::Error
-			fail "Timed out trying to access Nextcloud: #{uri.to_s}"
+			false
 		end
 	end
 
 	def wait_for_maintenance_mode_to_be_off
+		wait_for('Timed out waiting for maintenance mode to be off') do
+			!nextcloud_is_in_maintenance_mode
+		end
+	end
+
+	def wait_for_nextcloud_fixer
+		wait_for('Timed out waiting for Nextcloud Fixer to finish') do
+			!nextcloud_fixer_is_running
+		end
+	end
+
+	def wait_for(failure_message)
 		begin
 			Timeout.timeout(30) do
-				success = false
-				while not success
-					success = !nextcloud_is_in_maintenance_mode
+				while !yield
 					sleep 1
 				end
 			end
 		rescue Timeout::Error
-				fail "Timed out waiting for maintenance mode to be off"
+			fail failure_message
 		end
 	end
 
@@ -252,6 +254,11 @@ RSpec.configure do |config|
 
 	def nextcloud_is_in_maintenance_mode
 		`sudo snap run --shell nextcloud.occ -c '. "$SNAP/utilities/nextcloud-utilities" && nextcloud_is_in_maintenance_mode'`
+		$?.to_i == 0
+	end
+
+	def nextcloud_fixer_is_running
+		`snap services nextcloud.nextcloud-fixer | grep -qw active`
 		$?.to_i == 0
 	end
 


### PR DESCRIPTION
We have some tests that reinstall the snap, in which case Nextcloud Fixer runs, which is something that causes maintenance mode to be enabled. If the timing is Just Right (or Wrong, as the case may be), maintenance mode will be enabled right as a test is trying to log in, which causes the test to fail. Just wait for the Fixer to finish before trying anything.