### PR TITLE
php: bump interned strings buffer to a quarter of opcache buffer

### DIFF
--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -1770,10 +1770,12 @@ opcache.enable=1
 ;opcache.enable_cli=0
 
 ; The OPcache shared memory storage size.
-;opcache.memory_consumption=128
+opcache.memory_consumption=128
 
 ; The amount of memory for interned strings in Mbytes.
-;opcache.interned_strings_buffer=8
+; If we make it a quarter of the total opcache memory, Nextcloud won't whine
+; about it.
+opcache.interned_strings_buffer=32
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; Only numbers between 200 and 1000000 are allowed.


### PR DESCRIPTION
[Nextcloud is written](https://github.com/nextcloud/server/blob/03390ee791405aa399e00cc1b0220ae9e3c8d85e/apps/settings/lib/Controller/CheckSetupController.php#L526-L535) not to warn about the interned strings buffer size if it is at least a quarter of the total opcache buffer size. This means we can resolve #2024 without needing to make the buffer size configurable, which seems like a win.