### PR TITLE
Release 25.0.3snap2

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,7 +10,7 @@ jobs:
     environment: launchpad
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Fetch all history so we can push
           fetch-depth: 0

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nextcloud
         run: sudo snap install --edge nextcloud
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nextcloud
         run: sudo snap install nextcloud --channel=21/edge
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nextcloud
         run: sudo snap install nextcloud --channel=22/edge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: sudo apt-get update -qq && sudo apt-get install -qq shellcheck
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: sudo apt-get update -qq && sudo apt-get install -qq curl git
@@ -30,11 +30,11 @@ jobs:
         run: ./tests/run-tests.sh unit
 
   integration:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: sudo apt-get update -qq && sudo apt-get remove -qq lxd lxd-client && sudo snap install lxd && sudo lxd init --auto && sudo snap install --classic --channel=6.x/stable snapcraft

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v 25.0.3snap2
+  - php: bump interned strings buffer to a quarter of opcache buffer
+  - redis: update to 6.2.10
+
 v 25.0.3snap1
   - apache: update to 2.4.55
   - nextcloud: update to 25.0.3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -294,8 +294,8 @@ parts:
 
   redis:
     plugin: redis
-    source: https://download.redis.io/releases/redis-6.2.7.tar.gz
-    source-checksum: sha256/b7a79cc3b46d3c6eb52fa37dde34a4a60824079ebdfb3abfbbfa035947c55319
+    source: https://download.redis.io/releases/redis-6.2.10.tar.gz
+    source-checksum: sha256/22684f66d272379b91e3e53693918b535e2a6e54b9d14e1cad171658e0eefeca
 
   redis-customizations:
     plugin: dump

--- a/src/php/config/php.ini
+++ b/src/php/config/php.ini
@@ -1770,10 +1770,12 @@ opcache.enable=1
 ;opcache.enable_cli=0
 
 ; The OPcache shared memory storage size.
-;opcache.memory_consumption=128
+opcache.memory_consumption=128
 
 ; The amount of memory for interned strings in Mbytes.
-;opcache.interned_strings_buffer=8
+; If we make it a quarter of the total opcache memory, Nextcloud won't whine
+; about it.
+opcache.interned_strings_buffer=32
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; Only numbers between 200 and 1000000 are allowed.


### PR DESCRIPTION
- php: bump interned strings buffer to a quarter of opcache buffer
- redis: update to 6.2.10