### PR TITLE
ci: use ubuntu 20.04 instead of 18.04

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,7 +10,7 @@ jobs:
     environment: launchpad
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Fetch all history so we can push
           fetch-depth: 0

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nextcloud
         run: sudo snap install --edge nextcloud
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nextcloud
         run: sudo snap install nextcloud --channel=21/edge
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nextcloud
         run: sudo snap install nextcloud --channel=22/edge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: sudo apt-get update -qq && sudo apt-get install -qq shellcheck
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: sudo apt-get update -qq && sudo apt-get install -qq curl git
@@ -30,11 +30,11 @@ jobs:
         run: ./tests/run-tests.sh unit
 
   integration:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: sudo apt-get update -qq && sudo apt-get remove -qq lxd lxd-client && sudo snap install lxd && sudo lxd init --auto && sudo snap install --classic --channel=6.x/stable snapcraft


### PR DESCRIPTION
Github has deprecated 18.04 and to notify people is using brown outs, causing builds to fail. Update to 20.04. This should work fine given that we're building in a LXD container.