### PR TITLE
Release 25.0.4snap1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v 25.0.4snap1
+  - apache: update to 2.4.56
+  - redis: update to 6.2.11
+  - nextcloud: update to 25.0.4
+
 v 25.0.3snap3
   - php: update to 8.1.16
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-25.0.3.tar.bz2
-    source-checksum: sha256/4b2b1423736ef92469096fe24f61c24cad87a34e07c1c7a81b385d3ea25c00ec
+    source: https://download.nextcloud.com/server/releases/nextcloud-25.0.4.tar.bz2
+    source-checksum: sha256/c3251e0083a94303e2d6988b352f3b33082a79a726b30ff746709b0fe869a1a6
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,8 +134,8 @@ hooks:
 parts:
   apache:
     plugin: apache
-    source: https://dlcdn.apache.org/httpd/httpd-2.4.55.tar.bz2
-    source-checksum: sha256/11d6ba19e36c0b93ca62e47e6ffc2d2f2884942694bce0f23f39c71bdc5f69ac
+    source: https://dlcdn.apache.org/httpd/httpd-2.4.56.tar.bz2
+    source-checksum: sha256/d8d45f1398ba84edd05bb33ca7593ac2989b17cb9c7a0cafe5442d41afdb2d7c
     
     build-packages:
       - libbrotli-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -294,8 +294,8 @@ parts:
 
   redis:
     plugin: redis
-    source: https://download.redis.io/releases/redis-6.2.10.tar.gz
-    source-checksum: sha256/22684f66d272379b91e3e53693918b535e2a6e54b9d14e1cad171658e0eefeca
+    source: https://download.redis.io/releases/redis-6.2.11.tar.gz
+    source-checksum: sha256/8c75fb9cdd01849e92c23f30cb7fe205ea0032a38d11d46af191014e9acc3098
 
   redis-customizations:
     plugin: dump


### PR DESCRIPTION
- apache: update to 2.4.56
- redis: update to 6.2.11
- nextcloud: update to 25.0.4