### PR TITLE
Better document nextcloud.import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,10 @@ There are a few CLI utilities included:
     - Import data exported from another Nextcloud snap instance (via
       `nextcloud.export`). By default this imports the database, config, and
       data. See `nextcloud.import -h` for more information. Note that it
-      requires `sudo`.
+      requires `sudo`. The path needs to be available from confinement, 
+      so put it in /var/snap/nextcloud/common or /var/snap/nextcloud/current/ somewhere. 
+      User root needs to be the owner.
+
 
 
 ## Where is my stuff?


### PR DESCRIPTION
There is essential advice about restoring backups contained in the [wiki](https://github.com/nextcloud-snap/nextcloud-snap/wiki/How-to-backup-your-instance). Without this information I spent 40 minutes trying to understand vague rsync errors. I think other users would benefit by this information being placed in a more prominent position.