### PR TITLE
apache: update to 2.4.57

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,8 +134,8 @@ hooks:
 parts:
   apache:
     plugin: apache
-    source: https://dlcdn.apache.org/httpd/httpd-2.4.56.tar.bz2
-    source-checksum: sha256/d8d45f1398ba84edd05bb33ca7593ac2989b17cb9c7a0cafe5442d41afdb2d7c
+    source: https://dlcdn.apache.org/httpd/httpd-2.4.57.tar.bz2
+    source-checksum: sha256/dbccb84aee95e095edfbb81e5eb926ccd24e6ada55dcd83caecb262e5cf94d2a
     
     build-packages:
       - libbrotli-dev


### PR DESCRIPTION
This PR resolves #2370 by updating Apache to the latest v2.4 release.