### PR TITLE
Release 25.0.6snap1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v 25.0.6snap1
+  - nextcloud: update to 25.0.6
+  - mysql: update to 8.0.33
+  - apache: add mime type support for wasm
+  - redis: update to 6.2.12
+
 v 25.0.5snap2
   - apache: update to 2.4.57
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -294,8 +294,8 @@ parts:
 
   redis:
     plugin: redis
-    source: https://download.redis.io/releases/redis-6.2.11.tar.gz
-    source-checksum: sha256/8c75fb9cdd01849e92c23f30cb7fe205ea0032a38d11d46af191014e9acc3098
+    source: https://download.redis.io/releases/redis-6.2.12.tar.gz
+    source-checksum: sha256/75352eef41e97e84bfa94292cbac79e5add5345fc79787df5cbdff703353fb1b
 
   redis-customizations:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -339,8 +339,8 @@ parts:
     after: [boost]
 
     # Get from https://dev.mysql.com/downloads/mysql/
-    source: https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.32.tar.gz
-    source-checksum: md5/ac9445f619135336c8b4553d4e81b684
+    source: https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.33.tar.gz
+    source-checksum: md5/20ffc71fb8acd705cdc4a8ae4cdedf23
     configflags:
       - -DCMAKE_INSTALL_PREFIX=/
       - -DBUILD_CONFIG=mysql_release

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,8 +188,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-25.0.5.tar.bz2
-    source-checksum: sha256/c6dc632d83c62bd5741af5335dc13b6b0cde61064d3cd9a51ee0e6b4778ca9a5
+    source: https://download.nextcloud.com/server/releases/nextcloud-25.0.6.tar.bz2
+    source-checksum: sha256/7d8b4edc2679a0da5a22cf92f9e98caf1a98365724d000b8ddfc5d8a89ac8c38
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -185,6 +185,11 @@ LogLevel warn
 #
 TypesConfig conf/mime.types
 
+#
+# Add MIME types not present in Apache list of mappings needed for Nextcloud apps
+#
+AddType application/wasm .wasm
+
 # Disable HTTP TRACE method.
 TraceEnable off
 


### PR DESCRIPTION
- nextcloud: update to 25.0.6
- mysql: update to 8.0.33
- apache: add mime type support for wasm
- redis: update to 6.2.12