### PR TITLE
Use most recent certbot certs

### DIFF
--- a/src/https/utilities/https-utilities
+++ b/src/https/utilities/https-utilities
@@ -108,10 +108,10 @@ deactivate_certificates()
 
 activate_certbot_certificate()
 {
-	# There shouldn't be multiple domains here since we have no way to
-	# support them, but account for the possibility by simply taking the
-	# first domain's certificates. Ignore any READMEs.
-	certdir="$(find "$CERTBOT_LIVE_DIRECTORY" -maxdepth 1 -mindepth 1 -not -iname readme -printf "%P\n" | sort -n | head -1)"
+	# Multiple domains can accumulate if the user runs the command multiple
+	# times. So we find and use the folder that was most recently modified,
+	# which will contain the most recent certs. Ignore any READMEs.
+	certdir="$(find "$CERTBOT_LIVE_DIRECTORY" -maxdepth 1 -mindepth 1 -not -iname readme -printf "%T@ %P\n" | sort -rn | cut -d " " -f2 | head -1)"
 
 	deactivate_certificates
 	ln -s "$CERTBOT_LIVE_DIRECTORY/$certdir" "$LIVE_CERTS_DIRECTORY"


### PR DESCRIPTION
Resolves https://github.com/nextcloud-snap/nextcloud-snap/issues/2417. Sorts certbot cert directories by modified time and takes the most recent one.