### PR TITLE
import-data: Better documentation for nextcloud.import

### DIFF
--- a/src/import-export/bin/import-data
+++ b/src/import-export/bin/import-data
@@ -31,6 +31,11 @@ print_usage()
 	echo "    -b: Import the database"
 	echo "    -c: Import the config"
 	echo "    -d: Import the data"
+	echo ""
+	echo "Notice:"
+	echo "    The path needs to be available from confinement,"
+	echo "    so put it in /var/snap/nextcloud/common or /var/snap/nextcloud/current/ somewhere."
+	echo "    User root needs to be the owner."
 }
 
 import_apps()


### PR DESCRIPTION
Better documentation for nextcloud.import regarding the incomming data:
- `root` needs to be the owner
- only the `common` and `current` directory is valid

Just decided to copy over from the linked PR. Hope that's fine.

Resolves #2364