### PR TITLE
ci: enable 27 dailies

### DIFF
--- a/.github/spawn-dailies.sh
+++ b/.github/spawn-dailies.sh
@@ -4,7 +4,7 @@ latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar
 latest_stable24_url="https://download.nextcloud.com/server/daily/latest-stable24.tar.bz2"
 latest_stable25_url="https://download.nextcloud.com/server/daily/latest-stable25.tar.bz2"
 latest_stable26_url="https://download.nextcloud.com/server/daily/latest-stable26.tar.bz2"
-latest_stable26_url="https://download.nextcloud.com/server/daily/latest-stable27.tar.bz2"
+latest_stable27_url="https://download.nextcloud.com/server/daily/latest-stable27.tar.bz2"
 
 rewrite_snapcraft_yaml()
 {

--- a/.github/spawn-dailies.sh
+++ b/.github/spawn-dailies.sh
@@ -4,6 +4,7 @@ latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar
 latest_stable24_url="https://download.nextcloud.com/server/daily/latest-stable24.tar.bz2"
 latest_stable25_url="https://download.nextcloud.com/server/daily/latest-stable25.tar.bz2"
 latest_stable26_url="https://download.nextcloud.com/server/daily/latest-stable26.tar.bz2"
+latest_stable26_url="https://download.nextcloud.com/server/daily/latest-stable27.tar.bz2"
 
 rewrite_snapcraft_yaml()
 {
@@ -51,3 +52,8 @@ echo "Requesting build of latest 26..."
 request_build \
 	"latest-26" "$latest_stable26_url" "26-$today" \
 	"From CI: Use Nextcloud latest 26"
+
+echo "Requesting build of latest 27..."
+request_build \
+	"latest-27" "$latest_stable27_url" "27-$today" \
+	"From CI: Use Nextcloud latest 27"

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -76,3 +76,22 @@ jobs:
       - name: Run tests
         working-directory: tests
         run: bundle exec ./run-tests.sh integration
+
+  test-daily-v27:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install nextcloud
+        run: sudo snap install nextcloud --channel=27/edge
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          working-directory: tests
+          bundler-cache: true
+
+      - name: Run tests
+        working-directory: tests
+        run: bundle exec ./run-tests.sh integration


### PR DESCRIPTION
Fixes #2420 

Similar to changes by #2360. Hope that's fine.

Recommending squash and merge.

For NC24: Not sure how you handled that in past, but I suggest to keep for now as the `stable24` branche still get changes even if it's EOL (probably due enterprise).