### PR TITLE
Remove Nextcloud 24 dailies

### DIFF
--- a/.github/spawn-dailies.sh
+++ b/.github/spawn-dailies.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar.bz2"
-latest_stable24_url="https://download.nextcloud.com/server/daily/latest-stable24.tar.bz2"
 latest_stable25_url="https://download.nextcloud.com/server/daily/latest-stable25.tar.bz2"
 latest_stable26_url="https://download.nextcloud.com/server/daily/latest-stable26.tar.bz2"
 latest_stable27_url="https://download.nextcloud.com/server/daily/latest-stable27.tar.bz2"
@@ -37,11 +36,6 @@ echo "Requesting build of latest master..."
 request_build \
 	"latest-master" "$latest_master_url" "master-$today" \
 	"From CI: Use Nextcloud latest master"
-
-echo "Requesting build of latest 24..."
-request_build \
-	"latest-24" "$latest_stable24_url" "24-$today" \
-	"From CI: Use Nextcloud latest 24"
 
 echo "Requesting build of latest 25..."
 request_build \

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -24,25 +24,6 @@ jobs:
         working-directory: tests
         run: bundle exec ./run-tests.sh integration
 
-  test-daily-v24:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Install nextcloud
-        run: sudo snap install nextcloud --channel=24/edge
-
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          working-directory: tests
-          bundler-cache: true
-
-      - name: Run tests
-        working-directory: tests
-        run: bundle exec ./run-tests.sh integration
-
   test-daily-v25:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Dailies for Nextcloud 24 has been turned off since 12 July. See https://cloud.nextcloud.com/call/xs25tz5y#message_2014229.