### PR TITLE
Add config to enable notify_push reverse proxy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ If you want to disable the cronjob completely, run:
 
 To reenable it again simply set the `nextcloud.cron-interval` snap variable to a value that isn't `-1`
 
+
 #### HTTP compression configuration
 
 By default, the snap does not enable HTTP compression. To enable it, run:
@@ -125,6 +126,22 @@ By default, the snap does not enable HTTP compression. To enable it, run:
 To disable it, run:
 
     $ sudo snap set nextcloud http.compression=false
+
+
+#### Reverse Proxy for Files High Performance Backeend
+
+This option simply enables the reverse proxy configuration mentioned in [Client Push Readme](https://github.com/nextcloud/notify_push#apache) that is required to setup the `notify_push` component. Read more [at our wiki](https://github.com/nextcloud-snap/nextcloud-snap/wiki/FAQ's#q-how-to-install-files-hpb-client-push)!
+
+By default, the snap does not enable the reverse proxy for notify_push. To enable it, run:
+
+    $ sudo snap set nextcloud http.notify-push-reverse-proxy=true
+
+To disable it, run:
+
+    $ sudo snap set nextcloud http.notify-push-reverse-proxy=false
+
+Note: You still need to setup `notify_push` yourself. This option only enables the reverse proxy, as the apache configuration is read-only.
+
 
 #### Debug mode
 

--- a/src/apache/bin/httpd-wrapper
+++ b/src/apache/bin/httpd-wrapper
@@ -39,6 +39,13 @@ if debug_mode_enabled; then
 	params="$params -DDebug"
 fi
 
+if apache_notify_push_reverse_proxy_enabled; then
+	echo "notify_push reverse proxy is enabled"
+	params="$params -DEnableNotifyPushReverseProxy"
+else
+	echo "notify_push reverse proxy is disabled"
+fi
+
 
 HTTP_PORT="$(apache_http_port)"
 HTTPS_PORT="$(apache_https_port)"

--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -206,6 +206,13 @@ ServerSignature Off
     ServerSignature On
 </IfDefine>
 
+# Enable notify_push reverse proxy
+<IfDefine EnableNotifyPushReverseProxy>
+    ProxyPass /push/ws unix:/tmp/sockets/notify_push.sock|ws://localhost/ws
+    ProxyPass /push/ unix:/tmp/sockets/notify_push.sock|http://localhost/
+    ProxyPassReverse /push/ unix:/tmp/sockets/notify_push.sock|http://localhost/
+</IfDefine>
+
 # Only enable SSL if requested
 <IfDefine EnableHTTPS>
     Include ${SNAP}/conf/ssl.conf

--- a/src/apache/utilities/apache-utilities
+++ b/src/apache/utilities/apache-utilities
@@ -6,6 +6,7 @@
 DEFAULT_HTTP_PORT="80"
 DEFAULT_HTTPS_PORT="443"
 DEFAULT_HTTP_COMPRESSION="false"
+DEFAULT_HTTP_NOTIFY_PUSH_REVERSE_PROXY="false"
 
 : "${APACHE_PIDFILE:="/tmp/pids/httpd.pid"}"
 export APACHE_PIDFILE
@@ -152,4 +153,52 @@ _apache_get_previous_http_compression()
 _apache_set_previous_http_compression()
 {
 	snapctl set private.http.compression="$1"
+}
+
+apache_notify_push_reverse_proxy_enabled()
+{
+	[ "$(apache_get_notify_push_reverse_proxy_enabled)" = "true" ]
+}
+
+apache_enable_notify_push_reverse_proxy_enabled()
+{
+	_apache_set_notify_push_reverse_proxy_enabled "true"
+}
+
+apache_disable_notify_push_reverse_proxy_enabled()
+{
+	_apache_set_notify_push_reverse_proxy_enabled "false"
+}
+
+apache_notify_push_reverse_proxy_enabled_has_changed()
+{
+	[ "$(apache_get_notify_push_reverse_proxy_enabled)" != "$(_apache_get_previous_notify_push_reverse_proxy_enabled)" ]
+}
+
+apache_get_notify_push_reverse_proxy_enabled()
+{
+	notify_push_reverse_proxy="$(snapctl get http.notify-push-reverse-proxy)"
+
+	if [ -z "$notify_push_reverse_proxy" ]; then
+		notify_push_reverse_proxy="$DEFAULT_HTTP_NOTIFY_PUSH_REVERSE_PROXY"
+		_apache_set_notify_push_reverse_proxy_enabled "$notify_push_reverse_proxy"
+	fi
+
+	echo "$notify_push_reverse_proxy"
+}
+
+_apache_set_notify_push_reverse_proxy_enabled()
+{
+	snapctl set http.notify-push-reverse-proxy="$1"
+	_apache_set_previous_notify_push_reverse_proxy_enabled "$1"
+}
+
+_apache_get_previous_notify_push_reverse_proxy_enabled()
+{
+	snapctl get private.http.notify-push-reverse-proxy
+}
+
+_apache_set_previous_notify_push_reverse_proxy_enabled()
+{
+	snapctl set private.http.notify-push-reverse-proxy="$1"
 }

--- a/src/hooks/bin/configure
+++ b/src/hooks/bin/configure
@@ -19,6 +19,10 @@
 #   Whether or not HTTP compression should be enabled. Valid values are 'true'
 #   and 'false'.
 #
+# - http.notify-push-reverse-proxy (string)
+#   Whether or not the notify_push reverse proxy should be enabled. Valid
+#   values are 'true' and 'false'.
+#
 # - mode (string)
 #   Configure the operating mode of the snap. Valid values are 'debug' and
 #   'production'.
@@ -156,8 +160,27 @@ handle_http_compression()
 	snapctl restart nextcloud.apache
 }
 
+handle_notify_push_reverse_proxy()
+{
+	# If no changes were requested, then there's nothing to do here.
+	if ! apache_notify_push_reverse_proxy_enabled_has_changed; then
+		return 0
+	fi
+
+	# Validate input
+	value="$(apache_get_notify_push_reverse_proxy_enabled)"
+	if [ "$value" != "true" ] && [ "$value" != "false" ]; then
+		echo "http.notify-push-reverse-proxy must be either 'true' or 'false'"
+		return 1
+	fi
+
+	# Restart Apache to apply new config
+	snapctl restart nextcloud.apache
+}
+
 handle_apache_port_config
 handle_php_memory_limit
 handle_cronjob_interval
 handle_mode
 handle_http_compression
+handle_notify_push_reverse_proxy


### PR DESCRIPTION
Fix #1655

I used a few minutes and tried to implement a simple reverse proxy for the notiy_push component as a first step (see linked issue). It's probably all we can do. But this will already help a lot people to use the notify_push component **with encrypted https**!

In a later step we can maybe try to install and setup notify_push as additional component (maybe enabled by default). But 1. we would need to know the domain for the setup and 2. I have not the knowledge about the most programing stuff here. xP

## notify_push configuration

By default, the snap does not enable notify_push reverse proxy. To enable it, run:

    sudo snap set nextcloud http.notify-push-reverse-proxy=true

To disable it, run:

    sudo snap set nextcloud http.notify-push-reverse-proxy=false

## Some questions

1. @kyrofa What should we do with test? It is not possible to test the reverse proxy afaik. If there were a fully configured and running notify_push component then an empty page should be returned. when accessing https://cloud.mydomain.com/push/

2. What about the apache configuration? Is that correct on that place here or should I move it to `ssl.conf` to the `VirtualHost` section for https connection?

3. If the tests don't fail, would you @kyrofa please kick-off a build to `latest/beta/pr-2490`, so we can test that a bit?

4. Should I add an entry to the `README.md` file or just adjust the [wiki FAQ entry](https://github.com/nextcloud-snap/nextcloud-snap/wiki/FAQ's#q-how-to-install-files-hpb-client-push) I made a few weeks ago? In my opinion adjusting the wiki entry is enough as the config value is very special compared to the other ones. On the other side ont he README there is every single config option listed at the moment.

## Todo

- [x] Make a new [wiki page](https://github.com/nextcloud-snap/nextcloud-snap/wiki/Configure-HPB-client-push-for-Nextcloud-snap)
- [x] Make a [PR to notify_push repo](https://github.com/nextcloud/notify_push/pull/345)
- [ ] Remove the old [wiki FAQ entry](https://github.com/nextcloud-snap/nextcloud-snap/wiki/FAQ's#q-how-to-install-files-hpb-client-push) _(after merge!)_