### PR TITLE
ci: automatically deploy pushes to launchpad

### DIFF
--- a/.github/workflows/launchpad.yml
+++ b/.github/workflows/launchpad.yml
@@ -1,11 +1,15 @@
-name: Daily builds
+name: Deploy to Launchpad
 
 on:
-  schedule:
-  - cron: "0 0 * * *"
+  push:
+    # Only applies to our protected branches
+    branches:
+      - master
+      - develop
+      - '[0-9]+'
 
 jobs:
-  generate:
+  deploy:
     runs-on: ubuntu-latest
     environment: launchpad
     steps:
@@ -29,5 +33,5 @@ jobs:
       - name: Setup launchpad keys
         run: echo "${{ vars.LAUNCHPAD_SSH_PUBLIC_KEYS }}" > ~/.ssh/known_hosts
 
-      - name: Spawn builds
-        run: ./.github/spawn-dailies.sh
+      - name: Start Launchpad build
+        run: git push deploy "$GITHUB_REF_NAME"


### PR DESCRIPTION
This is basically just a synchronization of the protected branches from github to launchpad, and the automatic snap builds take over from there. Notably, this does not cover automatic deploys of snaps from pull requests; that is a bit more complex due to the potential to leak secrets.