### PR TITLE
mysql: revert commit be8348a7c3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -330,11 +330,18 @@ parts:
 
   mysql:
     plugin: cmake
-    after: [boost]
+    after: [boost, patches]
 
     # Get from https://dev.mysql.com/downloads/mysql/
     source: https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-boost-8.0.34.tar.gz
     source-checksum: md5/c8cfab52fbde1cca55accb3113c235eb
+    override-pull: |
+      snapcraftctl pull
+      patch -p1 $SNAPCRAFT_PART_SRC/mysys/CMakeLists.txt < $SNAPCRAFT_STAGE/mysql-mysys_CMakeLists.txt.patch
+      patch -p1 $SNAPCRAFT_PART_SRC/sql/memory/aligned_atomic.h < $SNAPCRAFT_STAGE/mysql-sql_memory_aligned_atomic.h.patch
+      patch -p1 $SNAPCRAFT_PART_SRC/unittest/gunit/memory/aligned_atomic-t.cc < $SNAPCRAFT_STAGE/mysql-unittest_gunit_memory_aligned_atomic-t.cc.patch
+      rm $SNAPCRAFT_PART_SRC/include/my_aligned_malloc.h
+      rm $SNAPCRAFT_PART_SRC/mysys/my_aligned_malloc.cc
     configflags:
       - -DCMAKE_INSTALL_PREFIX=/
       - -DBUILD_CONFIG=mysql_release

--- a/src/patches/mysql-mysys_CMakeLists.txt.patch
+++ b/src/patches/mysql-mysys_CMakeLists.txt.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt	2023-08-27 22:32:14.822992843 +0200
++++ b/CMakeLists.txt	2023-08-27 22:33:03.023469591 +0200
+@@ -55,7 +55,6 @@
+   mf_wcomp.cc
+   mulalloc.cc
+   my_access.cc
+-  my_aligned_malloc.cc
+   my_alloc.cc
+   my_bit.cc
+   my_bitmap.cc

--- a/src/patches/mysql-sql_memory_aligned_atomic.h.patch
+++ b/src/patches/mysql-sql_memory_aligned_atomic.h.patch
@@ -1,0 +1,147 @@
+--- a/sql/memory/aligned_atomic.h	2023-06-22 13:07:42.000000000 +0200
++++ b/sql/memory/aligned_atomic.h	2023-08-27 20:34:26.244493105 +0200
+@@ -38,9 +38,8 @@
+ #include <unistd.h>
+ #endif
+ 
+-#include "my_aligned_malloc.h"
+-
+ namespace memory {
++
+ /**
+  Calculates and returns the size of the CPU cache line.
+ 
+@@ -259,28 +258,14 @@
+ 
+     @return The pointer to the underlying `std::atomic<T>` object.
+    */
+-  std::atomic<T> *operator->();
+-  /*
+-    Pointer operator that allows the access to the underlying `std::atomic<T>`
+-    object.
+-
+-    @return The const pointer to the underlying `std::atomic<T>` object.
+-   */
+-  const std::atomic<T> *operator->() const;
++  std::atomic<T> *operator->() const;
+   /*
+     Dereference operator that allows the access to the underlying
+     `std::atomic<T>` object.
+ 
+     @return The reference to the underlying `std::atomic<T>` object.
+    */
+-  std::atomic<T> &operator*();
+-  /*
+-    Dereference operator that allows the access to the underlying
+-    `std::atomic<T>` object.
+-
+-    @return The const reference to the underlying `std::atomic<T>` object.
+-   */
+-  const std::atomic<T> &operator*() const;
++  std::atomic<T> &operator*() const;
+   /*
+     The size of `std::atomic<T>`, as returned by `sizeof std::atomic<T>`.
+ 
+@@ -298,7 +283,7 @@
+   /** The size of the byte buffer. */
+   size_t m_storage_size{0};
+   /** The byte buffer to use as underlying storage. */
+-  void *m_storage{nullptr};
++  alignas(std::max_align_t) unsigned char *m_storage{nullptr};
+   /** The pointer to the underlying `std::atomic<T>` object. */
+   std::atomic<T> *m_underlying{nullptr};
+ };
+@@ -306,10 +291,9 @@
+ 
+ template <typename T>
+ memory::Aligned_atomic<T>::Aligned_atomic()
+-    : m_storage_size{memory::minimum_cacheline_for<std::atomic<T>>()} {
+-  m_storage = my_aligned_malloc(m_storage_size, cache_line_size());
+-  m_underlying = new (this->m_storage) std::atomic<T>();
+-}
++    : m_storage_size{memory::minimum_cacheline_for<std::atomic<T>>()},
++      m_storage{new unsigned char[m_storage_size]},
++      m_underlying{new (this->m_storage) std::atomic<T>()} {}
+ 
+ template <typename T>
+ memory::Aligned_atomic<T>::Aligned_atomic(T value)
+@@ -318,16 +302,12 @@
+ }
+ 
+ template <typename T>
+-memory::Aligned_atomic<T>::Aligned_atomic(Aligned_atomic<T> &&rhs) {
+-  if (this->m_underlying != nullptr) {
+-    this->m_underlying->~atomic();
+-  }
+-  my_aligned_free(this->m_storage);
++memory::Aligned_atomic<T>::Aligned_atomic(Aligned_atomic<T> &&rhs)
++    : m_storage_size{rhs.m_storage_size}, m_underlying{rhs.m_underlying} {
++  delete[] this->m_storage;
+   this->m_storage = rhs.m_storage;
+-  this->m_storage_size = rhs.m_storage_size;
+-  this->m_underlying = rhs.m_underlying;
+-  rhs.m_storage = nullptr;
+   rhs.m_storage_size = 0;
++  rhs.m_storage = nullptr;
+   rhs.m_underlying = nullptr;
+ }
+ 
+@@ -335,25 +315,22 @@
+ memory::Aligned_atomic<T>::~Aligned_atomic() {
+   if (this->m_underlying != nullptr) {
+     this->m_underlying->~atomic();
++    this->m_underlying = nullptr;
+   }
+-  my_aligned_free(this->m_storage);
++  delete[] this->m_storage;
+   this->m_storage = nullptr;
+   this->m_storage_size = 0;
+-  this->m_underlying = nullptr;
+ }
+ 
+ template <typename T>
+ memory::Aligned_atomic<T> &memory::Aligned_atomic<T>::operator=(
+     Aligned_atomic<T> &&rhs) {
+-  if (this->m_underlying != nullptr) {
+-    this->m_underlying->~atomic();
+-  }
+-  my_aligned_free(this->m_storage);
+-  this->m_storage = rhs.m_storage;
++  delete[] this->m_storage;
+   this->m_storage_size = rhs.m_storage_size;
++  this->m_storage = rhs.m_storage;
+   this->m_underlying = rhs.m_underlying;
+-  rhs.m_storage = nullptr;
+   rhs.m_storage_size = 0;
++  rhs.m_storage = nullptr;
+   rhs.m_underlying = nullptr;
+   return (*this);
+ }
+@@ -393,25 +370,13 @@
+ }
+ 
+ template <typename T>
+-std::atomic<T> *memory::Aligned_atomic<T>::operator->() {
+-  assert(this->m_underlying != nullptr);
+-  return this->m_underlying;
+-}
+-
+-template <typename T>
+-const std::atomic<T> *memory::Aligned_atomic<T>::operator->() const {
++std::atomic<T> *memory::Aligned_atomic<T>::operator->() const {
+   assert(this->m_underlying != nullptr);
+   return this->m_underlying;
+ }
+ 
+ template <typename T>
+-std::atomic<T> &memory::Aligned_atomic<T>::operator*() {
+-  assert(this->m_underlying != nullptr);
+-  return *this->m_underlying;
+-}
+-
+-template <typename T>
+-const std::atomic<T> &memory::Aligned_atomic<T>::operator*() const {
++std::atomic<T> &memory::Aligned_atomic<T>::operator*() const {
+   assert(this->m_underlying != nullptr);
+   return *this->m_underlying;
+ }

--- a/src/patches/mysql-unittest_gunit_memory_aligned_atomic-t.cc.patch
+++ b/src/patches/mysql-unittest_gunit_memory_aligned_atomic-t.cc.patch
@@ -1,0 +1,50 @@
+--- a/unittest/gunit/memory/aligned_atomic-t.cc	2023-06-22 13:07:42.000000000 +0200
++++ b/unittest/gunit/memory/aligned_atomic-t.cc	2023-08-27 20:34:26.556495183 +0200
+@@ -25,9 +25,7 @@
+ #include <chrono>
+ #include <vector>
+ 
+-#define private public
+ #include "sql/memory/aligned_atomic.h"
+-#undef private
+ 
+ #include <gmock/gmock.h>
+ #include <gtest/gtest.h>
+@@ -59,37 +57,5 @@
+   EXPECT_EQ(atm3->load(), 2);
+ }
+ 
+-TEST_F(Aligned_atomic_test, minimum_cacheline_for) {
+-  EXPECT_EQ(memory::minimum_cacheline_for<char>(), memory::cache_line_size());
+-  EXPECT_EQ(memory::minimum_cacheline_for<int>(), memory::cache_line_size());
+-  EXPECT_EQ(memory::minimum_cacheline_for<std::atomic<bool>>(),
+-            memory::cache_line_size());
+-  EXPECT_EQ(memory::minimum_cacheline_for<std::atomic<int>>(),
+-            memory::cache_line_size());
+-}
+-
+-TEST_F(Aligned_atomic_test, aligned_allocation) {
+-  memory::Aligned_atomic<int> atm1{1};
+-  EXPECT_EQ((unsigned long long)atm1.m_underlying % memory::cache_line_size(),
+-            0);
+-
+-  memory::Aligned_atomic<bool> atm2{true};
+-  EXPECT_EQ((unsigned long long)atm2.m_underlying % memory::cache_line_size(),
+-            0);
+-
+-  memory::Aligned_atomic<short> atm3{0};
+-  EXPECT_EQ((unsigned long long)atm3.m_underlying % memory::cache_line_size(),
+-            0);
+-}
+-
+-TEST_F(Aligned_atomic_test, aligned_allocation_array) {
+-  static const int array_size = 10;
+-  memory::Aligned_atomic<int> atm[array_size];
+-
+-  for (int i = 0; i < array_size; i++)
+-    EXPECT_EQ(
+-        (unsigned long long)atm[i].m_underlying % memory::cache_line_size(), 0);
+-}
+-
+ }  // namespace unittests
+ }  // namespace memory


### PR DESCRIPTION
Apply the same solution that Ubuntu to solve https://bugs.launchpad.net/ubuntu/+source/mysql-8.0/+bug/2019203, which we think is the same bug that is biting some snap users.

It should fix #2405

Note: once is out in a month or so, we should allow for affected users to test if next MySQL release (8.0.35) includes [the proper fix for the bug](https://bugs.mysql.com/bug.php?id=110752) and we can then discard this patch. 