### PR TITLE
PR snap releaser: detect triggering pull request in fork-compatible way

### DIFF
--- a/.github/workflows/release-pr-snap.yml
+++ b/.github/workflows/release-pr-snap.yml
@@ -47,19 +47,21 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const workflowRun = await github.rest.actions.getWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }},
-            });
+            const pullRequests = await github.paginate(
+              `GET /repos/${process.env.GITHUB_REPOSITORY}/pulls`,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              }
+            );
 
-            const pullRequestCount = workflowRun.data.pull_requests.length;
+            const matchingPullRequests = pullRequests.filter(pr => pr.head.sha === '${{ steps.determine-sha.outputs.result }}');
+            const pullRequestCount = matchingPullRequests.length;
             if (pullRequestCount != 1) {
-              throw new Error(`Expected one pull request, but got ${pullRequestCount}`);
+              throw new Error(`Expected one pull request to contain commit, but got ${pullRequestCount}`);
             }
 
-            const pullRequest = workflowRun.data.pull_requests[0];
-            return `latest/beta/pr-${pullRequest.number}`;
+            return `latest/beta/pr-${matchingPullRequests[0].number}`;
 
       - name: Download snap artifact
         uses: actions/github-script@v6


### PR DESCRIPTION
2df9c560119a2544774f11101006d9d25ab67cb1 used the Workflow Run info in the GitHub API to determine the pull request that triggered it. Sadly that information doesn't appear to be filled out properly if the pull request in question is coming from a fork. Use a more brute-force method instead, searching through every open pull request for the commit that triggered the workflow in question.