### PR TITLE
snapcraft: use branch 7.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get remove -qq lxd lxd-client && sudo snap install lxd && sudo lxd init --auto && sudo snap install --classic --channel=6.x/stable snapcraft
+        run: sudo apt-get update -qq && sudo apt-get remove -qq lxd lxd-client && sudo snap install lxd && sudo lxd init --auto && sudo snap install --classic --channel=7.x/stable snapcraft
 
       # Using sudo here because our CI user isn't a member of the lxd group
       - name: Build snap


### PR DESCRIPTION
The bug that was hitting us has been solved in 7.5.3: https://github.com/snapcore/snapcraft/issues/4285

We have to stick with 7.x, as 8.x will deprecate `core18` snaps.

If this works, we will need to update snap building options on Launchpad too.

Fixes #2122