### PR TITLE
ci/cd: tune ext4 for speed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,19 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      # Inspired by https://github.com/canonical/lxd/pull/12385
+      - name: Performance tuning
+        run: |
+          set -eux
+          # optimize ext4 FSes for performance, not reliability
+          for fs in $(findmnt --noheading --type ext4 --list --uniq | awk '{print $1}'); do
+            # nombcache and data=writeback cannot be changed on remount
+            sudo mount -o remount,noatime,barrier=0,commit=6000 "${fs}"
+          done
+
+          # disable dpkg from calling sync()
+          echo "force-unsafe-io" | sudo tee /etc/dpkg/dpkg.cfg.d/force-unsafe-io
+
       - name: Check out code
         uses: actions/checkout@v3
 


### PR DESCRIPTION
I want to test if builds are quicker with this change.

Inspired by https://github.com/canonical/lxd/pull/12385