### PR TITLE
apache: use archive site instead of dlcdn

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,7 +127,7 @@ hooks:
 parts:
   apache:
     plugin: apache
-    source: https://dlcdn.apache.org/httpd/httpd-2.4.58.tar.bz2
+    source: https://archive.apache.org/dist/httpd/httpd-2.4.58.tar.bz2
     source-checksum: sha256/fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c5
     
     build-packages:


### PR DESCRIPTION
Apache only hosts the latest version of the HTTPD server on https://dlcdn.apache.org/httpd/ so use
http://archive.apache.org/dist/httpd/ istead, which holds all versions.

Fix #2579