### PR TITLE
ci: add tests for nextcloud 28

### DIFF
--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -24,21 +24,6 @@ jobs:
         working-directory: tests
         run: bundle exec ./run-tests.sh integration
 
-  test-daily-v25:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Install nextcloud
-        run: sudo snap install nextcloud --channel=25/edge
-
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          working-directory: tests
-          bundler-cache: true
-
   test-daily-v26:
     runs-on: ubuntu-latest
     steps:
@@ -66,6 +51,25 @@ jobs:
 
       - name: Install nextcloud
         run: sudo snap install nextcloud --channel=27/edge
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          working-directory: tests
+          bundler-cache: true
+
+      - name: Run tests
+        working-directory: tests
+        run: bundle exec ./run-tests.sh integration
+
+  test-daily-v28:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install nextcloud
+        run: sudo snap install nextcloud --channel=28/edge
 
       - name: Setup ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Missed that in my last PR, so here is the new one.

Not sure if you still want to target `develop`, just change it if you want to merge to `master` directly.