### PR TITLE
php: enable sodium

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -213,6 +213,7 @@ parts:
       - --with-curl
       - --with-openssl
       - --with-bz2
+      - --with-sodium
       - --enable-exif
       - --enable-intl
       - --enable-pcntl
@@ -275,6 +276,7 @@ parts:
       - libzip4
       - libargon2-0
       - libonig4
+      - libsodium23
     prime:
      - -sbin/
      - -etc/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -249,6 +249,7 @@ parts:
       - libgmp-dev
       - libzip-dev
       - libargon2-0-dev
+      - libsodium-dev
 
       # This is no longer bundled with PHP as of v7.4
       - libonig-dev


### PR DESCRIPTION
This resolved the nice warning in NC28 by installing the php sodium extension. 

Fix #2643
Required for #2641 

![grafik](https://github.com/nextcloud-snap/nextcloud-snap/assets/23138465/6559facc-ad63-471a-a71b-b4ecf0ae79a7)

It is a recommended php module by Nextcloud:
> PHP module sodium (for Argon2 for password hashing. bcrypt is used as fallback, but if passwords were hashed with Argon2 already and the module is missing, your users can’t log in.)