### PR TITLE
Release 26.0.13snap1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v 26.0.13snap1
+  - nextcloud: update to 26.0.13
+  - apache: update to 2.4.59
+
 v 26.0.10snap1
   - nextcloud: update to 26.0.10
 


### PR DESCRIPTION
I've tested an upgrade from the `26/stable` channel (26.0.10) to the `26/beta` one (26.0.13) and it worked OK.