### PR TITLE
ci: enable dailies for nextcloud 29

### DIFF
--- a/.github/spawn-dailies.sh
+++ b/.github/spawn-dailies.sh
@@ -4,6 +4,7 @@ latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar
 latest_stable26_url="https://download.nextcloud.com/server/daily/latest-stable26.tar.bz2"
 latest_stable27_url="https://download.nextcloud.com/server/daily/latest-stable27.tar.bz2"
 latest_stable28_url="https://download.nextcloud.com/server/daily/latest-stable28.tar.bz2"
+latest_stable29_url="https://download.nextcloud.com/server/daily/latest-stable29.tar.bz2"
 
 rewrite_snapcraft_yaml()
 {
@@ -51,3 +52,8 @@ echo "Requesting build of latest 28..."
 request_build \
 	"latest-28" "$latest_stable28_url" "28-$today" \
 	"From CI: Use Nextcloud latest 28"
+
+echo "Requesting build of latest 29..."
+request_build \
+	"latest-29" "$latest_stable29_url" "29-$today" \
+	"From CI: Use Nextcloud latest 29"

--- a/.github/spawn-dailies.sh
+++ b/.github/spawn-dailies.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar.bz2"
-latest_stable26_url="https://download.nextcloud.com/server/daily/latest-stable26.tar.bz2"
 latest_stable27_url="https://download.nextcloud.com/server/daily/latest-stable27.tar.bz2"
 latest_stable28_url="https://download.nextcloud.com/server/daily/latest-stable28.tar.bz2"
 latest_stable29_url="https://download.nextcloud.com/server/daily/latest-stable29.tar.bz2"
@@ -37,11 +36,6 @@ echo "Requesting build of latest master..."
 request_build \
 	"latest-master" "$latest_master_url" "master-$today" \
 	"From CI: Use Nextcloud latest master"
-
-echo "Requesting build of latest 26..."
-request_build \
-	"latest-26" "$latest_stable26_url" "26-$today" \
-	"From CI: Use Nextcloud latest 26"
 
 echo "Requesting build of latest 27..."
 request_build \

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -80,3 +80,22 @@ jobs:
       - name: Run tests
         working-directory: tests
         run: bundle exec ./run-tests.sh integration
+
+  test-daily-v29:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install nextcloud
+        run: sudo snap install nextcloud --channel=29/edge
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          working-directory: tests
+          bundler-cache: true
+
+      - name: Run tests
+        working-directory: tests
+        run: bundle exec ./run-tests.sh integration

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -24,25 +24,6 @@ jobs:
         working-directory: tests
         run: bundle exec ./run-tests.sh integration
 
-  test-daily-v26:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Install nextcloud
-        run: sudo snap install nextcloud --channel=26/edge
-
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          working-directory: tests
-          bundler-cache: true
-
-      - name: Run tests
-        working-directory: tests
-        run: bundle exec ./run-tests.sh integration
-
   test-daily-v27:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fix #2737

Leaving dailies for nextcloud 26 as they still get generated on nextcloud.