### PR TITLE
httpd.conf: update javascript MIME types to compress

### DIFF
--- a/src/apache/conf/httpd.conf
+++ b/src/apache/conf/httpd.conf
@@ -54,10 +54,11 @@ PidFile "${APACHE_PIDFILE}"
   # https://github.com/nextcloud/documentation/blob/master/admin_manual/installation/nginx.rst
   # https://blog.cloudflare.com/results-experimenting-brotli/
   # https://blogs.akamai.com/2016/02/understanding-brotlis-potential.html
+  # https://github.com/nextcloud/all-in-one/pull/2576
   #
   Header append Vary User-Agent
   BrotliCompressionQuality 1
-  AddOutputFilterByType BROTLI_COMPRESS application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy
+  AddOutputFilterByType BROTLI_COMPRESS application/atom+xml application/javascript text/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy
 </IfDefine>
 
 # 'Main' server configuration


### PR DESCRIPTION
We weren't compressing JS files because we were missing the correct MIME type in the `AddOutputFilterByType` directive.

Fixes #2779