### PR TITLE
php: enable sqlite3 & pdo-sqlite

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -234,9 +234,6 @@ parts:
       # Enable argon2
       - --with-password-argon2
 
-      # Disable sqlite (we use mysql)
-      - --without-sqlite3
-      - --without-pdo-sqlite
     build-packages:
       - libxml2-dev
       - libcurl4-openssl-dev
@@ -252,6 +249,7 @@ parts:
       - libsodium-dev
       - libaio-dev
       - libaio1
+      - libsqlite3-dev
 
       # This is no longer bundled with PHP as of v7.4
       - libonig-dev
@@ -281,6 +279,7 @@ parts:
       - libonig4
       - libsodium23
       - libaio1
+      - libsqlite3-0
     prime:
      - -sbin/
      - -etc/


### PR DESCRIPTION
Fix #2744

Need to be tested, not sure if we need to enable something explicitely or if its enough to remove the disable lines.