### PR TITLE
Release 30.0.1snap1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 30.0.1snap1
+  - nextcloud: update to 30.0.1
+
 v 29.0.8snap1
   - nextcloud: update to 29.0.8
   - php: update to 8.2.24

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Nextcloud server packaged as a snap. It consists of:
 
-- Nextcloud 29
+- Nextcloud 30
 - Apache 2.4
 - PHP 8.2
 - MySQL 8

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -187,6 +187,7 @@ parts:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess
       '.user.ini': htdocs/.user.ini
+      '.reuse': htdocs/.reuse
 
     # This snap automatically updates. No need to include the updater to nag
     # users. This does not result in an integrity check failure.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -181,8 +181,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-29.0.8.tar.bz2
-    source-checksum: sha256/0ab54b517f76cd26f2bd38b6fe184b9fbaed32f734246c58c1acf83473c0a4b9
+    source: https://download.nextcloud.com/server/releases/nextcloud-30.0.1.tar.bz2
+    source-checksum: sha256/79ec2ffad6231bd8fcc4abaacc12e5ac51e670d089affb379483592cda0fdccb
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
I know it might be a bit early, but I just had the time to quickly make a release PR. You might want to wait a few more days, no problem.

The new version works flowless for me without any problem for my private production instance. Keep in mind that I have many third-party apps installed.

Additionally fixes #2933 and closes #2898 *(writing those here because they weren't mentoined in any commit message)*