### PR TITLE
actions: upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         run: bundle exec ./run-tests.sh integration
 
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snap
           path: '*.snap'


### PR DESCRIPTION
actions/upload-artifact@v3 will be deprecated by December 5, 2024.

The breaking changes are documented [here](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). For our use case there shouldn't be problems, but who knows.
