### PR TITLE
actions: workaround checkout action not fetching annotated tags

### DIFF
--- a/.github/workflows/launchpad.yml
+++ b/.github/workflows/launchpad.yml
@@ -20,7 +20,9 @@ jobs:
         with:
           # Fetch all history so we can push
           fetch-depth: 0
-          fetch-tags: true
+
+      - name: Fetch tags with annotations
+        run: git fetch --tags --force origin # WA: https://github.com/actions/checkout/issues/882
 
       - name: Setup git
         run: |


### PR DESCRIPTION
Second try at solving the problem we have with Launchpad just getting lightweight tags from the action. More context https://github.com/nextcloud-snap/nextcloud-snap/issues/2966#issuecomment-2502193356.