### PR TITLE
github: add the backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,28 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: sourcegraph/backport@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # See https://github.com/sourcegraph/backport/pull/14
+          team_reviews: ''


### PR DESCRIPTION
Second attempt at this after https://github.com/nextcloud-snap/nextcloud-snap/pull/2603.

This one comes from the https://github.com/sourcegraph/backport fork.

It works with labels and opens PR. Instructions [here](https://github.com/sourcegraph/backport).
It should make backporting to old-but-still-supported nextcloud versions less manual.