### PR TITLE
ci: enable dailies for nextcloud 31

### DIFF
--- a/.github/spawn-dailies.sh
+++ b/.github/spawn-dailies.sh
@@ -3,6 +3,7 @@
 latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar.bz2"
 latest_stable29_url="https://download.nextcloud.com/server/daily/latest-stable29.tar.bz2"
 latest_stable30_url="https://download.nextcloud.com/server/daily/latest-stable30.tar.bz2"
+latest_stable31_url="https://download.nextcloud.com/server/daily/latest-stable31.tar.bz2"
 
 rewrite_snapcraft_yaml()
 {
@@ -45,3 +46,8 @@ echo "Requesting build of latest 30..."
 request_build \
 	"latest-30" "$latest_stable30_url" "30-$today" \
 	"From CI: Use Nextcloud latest 30"
+
+echo "Requesting build of latest 31..."
+request_build \
+	"latest-31" "$latest_stable31_url" "31-$today" \
+	"From CI: Use Nextcloud latest 31"


### PR DESCRIPTION
Fix #3074 

- [x] Requies this file to exists: https://download.nextcloud.com/server/daily/latest-stable31.tar.bz2
Reference: https://cloud.nextcloud.com/call/xs25tz5y#message_3728500