### PR TITLE
tests: workaround intermitent failing of integration tests

### DIFF
--- a/tests/integration/change_php_memory_limit_spec.rb
+++ b/tests/integration/change_php_memory_limit_spec.rb
@@ -46,6 +46,7 @@ feature "Change PHP memory limit" do
 		fill_in "user", with: "admin"
 		fill_in "password", with: "admin"
 		click_button "Log in"
+		sleep 3
 		expect(page).to have_content /(Recommended|All) files/
 	end
 

--- a/tests/integration/enable_https_spec.rb
+++ b/tests/integration/enable_https_spec.rb
@@ -10,6 +10,7 @@ feature "Enabling HTTPS" do
 		fill_in "user", with: "admin"
 		fill_in "password", with: "admin"
 		click_button "Log in"
+		sleep 3
 		expect(page).to have_content /(Recommended|All) files/
 	end
 end

--- a/tests/integration/import_export_spec.rb
+++ b/tests/integration/import_export_spec.rb
@@ -40,6 +40,7 @@ feature "Import and export data" do
 		fill_in "user", with: "admin"
 		fill_in "password", with: "admin"
 		click_button "Log in"
+		sleep 3
 		expect(page).to have_content /(Recommended|All) files/
 	end
 end

--- a/tests/integration/login_spec.rb
+++ b/tests/integration/login_spec.rb
@@ -4,6 +4,7 @@ feature "Logging in" do
 		fill_in "user", with: "admin"
 		fill_in "password", with: "admin"
 		click_button "Log in"
+		sleep 3
 		expect(page).to have_content /(Recommended|All) files/
 	end
 
@@ -12,6 +13,7 @@ feature "Logging in" do
 		fill_in "user", with: "wronguser"
 		fill_in "password", with: "wrongpassword"
 		click_button "Log in"
+		sleep 3
 		expect(page).to have_content /Wrong.*password/
 	end
 end


### PR DESCRIPTION
The problem seems to be with the newest chromium 134. More context here: https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2727634699 We should be able to remove the sleeps once the upstream problem is solved.