### PR TITLE
run ci only on protected branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,16 @@
 name: Run tests against changes
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - master
+      - develop
+      - '[0-9]+'
+    tags:
+      - '*'
 
 jobs:
   static:


### PR DESCRIPTION
Does what it says. Made a PR a year ago already but it didn't get merged or reviewed. Another try, now that I know @kyrofa would accept it probably. :)

It's the same way like I've seen for ohter organizations.