### PR TITLE
Update Nextcloud to 31.0.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -181,8 +181,8 @@ parts:
 
   nextcloud:
     plugin: dump
-    source: https://download.nextcloud.com/server/releases/nextcloud-30.0.6.tar.bz2
-    source-checksum: sha256/ac0e091be6920965dc0c82f149b632d6b5ade7adee84a7b3c8cfd847450a8ddc
+    source: https://download.nextcloud.com/server/releases/nextcloud-31.0.2.tar.bz2
+    source-checksum: sha256/00b572111b7c2b98842d95c046de79ef463ccfadc8a04b54006c786e1f94c310
     organize:
       '*': htdocs/
       '.htaccess': htdocs/.htaccess


### PR DESCRIPTION
What's Changed

    [stable31] fix(mime-types): adjust compiled mime types and sign by @backportbot in https://github.com/nextcloud/server/pull/51437
    [stable31] fix(encryption): Listen for user login and logout to set encryption key by @backportbot in https://github.com/nextcloud/server/pull/51311
    [stable31] Allow to delete files without trashbin + add unit tests + some refactoring by @backportbot in https://github.com/nextcloud/server/pull/51397
    [stable31] fix(dav): Fix share token pattern for base uri extraction by @backportbot in https://github.com/nextcloud/server/pull/51396
    [stable31] fix(RichObjectStrings): Make exception messages for invalid parameters more useful for debugging by @backportbot in https://github.com/nextcloud/server/pull/51445
    [stable31] test: Remove .only() calls by @backportbot in https://github.com/nextcloud/server/pull/51304
    [stable31] ci: Update 3rdparty actions by @nickvergessen in https://github.com/nextcloud/server/pull/51519
    [stable31] fix(comments): Fix activity rich subject parameters by @backportbot in https://github.com/nextcloud/server/pull/51515
    [stable31] fix(base.php): Correct order for booting \OC\Server by @backportbot in https://github.com/nextcloud/server/pull/51371
    [stable31] fix(files): Make sure file pointer exists by @backportbot in https://github.com/nextcloud/server/pull/51536
    [stable31] fix(auth): Allow 2FA challenges for Ephemeral sessions by @backportbot in https://github.com/nextcloud/server/pull/51549
    31.0.2 RC1 by @Altahrim in https://github.com/nextcloud/server/pull/51552
    31.0.2 by @blizzz in https://github.com/nextcloud/server/pull/51575