### PR TITLE
Enable dailies for nextcloud 32

### DIFF
--- a/.github/spawn-dailies.sh
+++ b/.github/spawn-dailies.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 latest_master_url="https://download.nextcloud.com/server/daily/latest-master.tar.bz2"
-latest_stable29_url="https://download.nextcloud.com/server/daily/latest-stable29.tar.bz2"
 latest_stable30_url="https://download.nextcloud.com/server/daily/latest-stable30.tar.bz2"
 latest_stable31_url="https://download.nextcloud.com/server/daily/latest-stable31.tar.bz2"
+latest_stable32_url="https://download.nextcloud.com/server/daily/latest-stable32.tar.bz2"
 
 rewrite_snapcraft_yaml()
 {
@@ -46,3 +46,8 @@ echo "Requesting build of latest 31..."
 request_build \
 	"latest-31" "$latest_stable31_url" "31-$today" \
 	"From CI: Use Nextcloud latest 31"
+
+echo "Requesting build of latest 32..."
+request_build \
+	"latest-32" "$latest_stable32_url" "32-$today" \
+	"From CI: Use Nextcloud latest 32"

--- a/.github/workflows/test-daily.yml
+++ b/.github/workflows/test-daily.yml
@@ -31,7 +31,45 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install nextcloud
-        run: sudo snap install nextcloud --channel=29/edge
+        run: sudo snap install nextcloud --channel=30/edge
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@cf7216d52fba1017929b4d7162fabe2b30af5b49 # v1.262.0
+        with:
+          working-directory: tests
+          bundler-cache: true
+
+      - name: Run tests
+        working-directory: tests
+        run: bundle exec ./run-tests.sh integration
+
+  test-daily-v31:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install nextcloud
+        run: sudo snap install nextcloud --channel=31/edge
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@cf7216d52fba1017929b4d7162fabe2b30af5b49 # v1.262.0
+        with:
+          working-directory: tests
+          bundler-cache: true
+
+      - name: Run tests
+        working-directory: tests
+        run: bundle exec ./run-tests.sh integration
+
+  test-daily-v32:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install nextcloud
+        run: sudo snap install nextcloud --channel=32/edge
 
       - name: Setup ruby
         uses: ruby/setup-ruby@cf7216d52fba1017929b4d7162fabe2b30af5b49 # v1.262.0


### PR DESCRIPTION
Fix #3278 

- Enables dailies for Nextcloud 32
- Removees obsolte dailies url for Nextcloud 29
- Fixes tests for dailies of Nextcloud 30
- Adds tests for dailies for Nextcloud 31

~~Requires the tarball [`latest-stable31.tar.bz2`](https://download.nextcloud.com/server/daily/latest-stable32.tar.bz2) to be available! Already [requrested here](https://cloud.nextcloud.com/call/xs25tz5y#message_4447884), let's wait for an response.~~ --> Done!